### PR TITLE
fix(core): Ignore changes in unrelated query parameters

### DIFF
--- a/projects/ngqp/core/src/lib/util.ts
+++ b/projects/ngqp/core/src/lib/util.ts
@@ -1,3 +1,4 @@
+import { convertToParamMap, ParamMap, Params } from '@angular/router';
 import { Comparator } from './types';
 
 /** @internal */
@@ -51,4 +52,48 @@ export function areEqualUsing<T>(first: T, second: T, comparator: Comparator<T>)
     }
 
     return comparison === 0;
+}
+
+/** @internal */
+export function filterParamMap(paramMap: ParamMap, keys: string[]): ParamMap {
+    const params: Params = {};
+    keys
+        .filter(key => paramMap.keys.includes(key))
+        .forEach(key => params[ key ] = paramMap.getAll(key));
+
+    return convertToParamMap(params);
+}
+
+/** @internal */
+export function compareParamMaps(first: ParamMap, second: ParamMap): boolean {
+    if ((first && !second) || (second && !first)) {
+        return false;
+    }
+
+    if (!compareStringArraysUnordered(first.keys, second.keys)) {
+        return false;
+    }
+
+    return first.keys.every(key =>
+        compareStringArraysUnordered(first.getAll(key), second.getAll(key))
+    );
+}
+
+/** @internal */
+export function compareStringArraysUnordered(first: string[], second: string[]): boolean {
+    if (!first && !second) {
+        return true;
+    }
+
+    if ((first && !second) || (second && !first)) {
+        return false;
+    }
+
+    if (first.length !== second.length) {
+        return false;
+    }
+
+    const sortedFirst = first.sort();
+    const sortedSecond = second.sort();
+    return sortedFirst.every((firstKey, index) => firstKey === sortedSecond[index]);
 }

--- a/projects/ngqp/core/src/test/empty-on.spec.ts
+++ b/projects/ngqp/core/src/test/empty-on.spec.ts
@@ -75,6 +75,11 @@ describe('emptyOn', () => {
     }));
 
     it('sets the form control value to the specified default if the query parameter is not set', fakeAsync(() => {
+        // Set the parameter on the route so it can actually disappear, otherwise no event
+        // is (and should be) sent
+        router.navigateByUrl(`/?q1=x`);
+        tick();
+
         input1.value = 'Other';
         fixture.detectChanges();
 

--- a/projects/ngqp/core/src/test/group-remove.spec.ts
+++ b/projects/ngqp/core/src/test/group-remove.spec.ts
@@ -72,9 +72,7 @@ describe('QueryParamGroup#remove', () => {
             router.navigateByUrl('/?q=Test');
             tick();
 
-            expectObservable(groupValue$).toBe('a', {
-                a: {},
-            });
+            expectObservable(groupValue$).toBe('');
             expectObservable(value$).toBe('');
         });
     }));

--- a/projects/ngqp/core/src/test/input-text.spec.ts
+++ b/projects/ngqp/core/src/test/input-text.spec.ts
@@ -124,4 +124,15 @@ describe('ngqp', () => {
             expectObservable(paramValueChanges$).toBe('');
         });
     }));
+
+    it('does not emit if unrelated URL parameters change', fakeAsync(() => {
+        scheduler.run(({ expectObservable }) => {
+            const value$ = captureObservable(component.paramGroup.valueChanges);
+
+            router.navigateByUrl(`/?unrelated=42`);
+            tick();
+
+            expectObservable(value$).toBe('');
+        });
+    }));
 });


### PR DESCRIPTION
If a group defines only a param "foo", changing the URL to /?bar=1 should
be ignored as nothing of interest to this QueryParamGroup has changed.

fixes #81

Signed-off-by: Ingo Bürk <ingo.buerk@tngtech.com>

<!--
Thank you for contributing to @ngqp! Please read the following and make sure your PR is following this template.
-->

<!-- Provide a list of issue numbers relating to this PR -->
This pull request relates to or closes the following issues:

I have verified that…
- [x] the commits in this pull request follow the [conventionalcommits](https://www.conventionalcommits.org) pattern
- [x] tests have been updated or added
- [x] documentation has been updated to reflect the changes made
