### PR TITLE
[Solution #1] fix(core): Improve typing and support emptyOn for multi:true

### DIFF
--- a/projects/ngqp-demo/src/app/docs-items/configuration/query-param/query-param-configuration-docs.component.html
+++ b/projects/ngqp-demo/src/app/docs-items/configuration/query-param/query-param-configuration-docs.component.html
@@ -54,9 +54,6 @@
     <docs-fragment fragment="emptyOn-compareWith">
         <h2>Default values</h2>
     </docs-fragment>
-    <div class="alert alert-warning">
-        This feature is currently not supported if you are using <span apiDocsLink>QueryParam#multi</span>.
-    </div>
     <p>
         By default, if a parameter value is <code>null</code>, the parameter will be removed from the URL. For example,
         this prevents useless URL segments such as <code>?q=</code> (without a value). However, in some cases you might

--- a/projects/ngqp-demo/src/app/docs-items/examples/manual-wiring-example/manual-wiring-example.component.ts
+++ b/projects/ngqp-demo/src/app/docs-items/examples/manual-wiring-example/manual-wiring-example.component.ts
@@ -29,7 +29,6 @@ export class ManualWiringExampleComponent implements OnDestroy {
         this.pageParam.valueChanges.pipe(
             takeUntil(this.componentDestroyed$)
         ).subscribe(page => this.currentPage = page);
-
     }
 
     public get pageParam(): QueryParam<number> {

--- a/projects/ngqp/core/src/lib/core.ts
+++ b/projects/ngqp/core/src/lib/core.ts
@@ -2,8 +2,6 @@ export { QueryParamBuilder } from './query-param-builder.service';
 export { QueryParamModule } from './query-param.module';
 
 export {
-    createEmptyOnSerializer,
-    createEmptyOnDeserializer,
     createStringSerializer,
     createStringDeserializer,
     createNumberSerializer,

--- a/projects/ngqp/core/src/lib/model/model.ts
+++ b/projects/ngqp/core/src/lib/model/model.ts
@@ -1,3 +1,3 @@
-export { QueryParamOpts } from './query-param-opts';
+export { QueryParamOpts, MultiQueryParamOpts } from './query-param-opts';
 export { QueryParamGroup } from './query-param-group';
-export { QueryParam } from './query-param';
+export { QueryParam, MultiQueryParam } from './query-param';

--- a/projects/ngqp/core/src/lib/model/query-param-opts.ts
+++ b/projects/ngqp/core/src/lib/model/query-param-opts.ts
@@ -1,23 +1,23 @@
-import { Comparator, ParamCombinator, ParamDeserializer, ParamSerializer, Unpack } from '../types';
+import { Comparator, ParamCombinator, ParamDeserializer, ParamSerializer } from '../types';
 
 /**
  * List of options which can be passed to {@link QueryParam}.
  */
-export interface QueryParamOpts<T> {
+export interface QueryParamOpts<U, T = U> {
 
     /**
      * The serializer used for this parameter.
      *
      * See {@link ParamSerializer}.
      */
-    serialize?: ParamSerializer<Unpack<T>>;
+    serialize?: ParamSerializer<U>;
 
     /**
      * The deserializer used for this parameter.
      *
      * See {@link ParamDeserializer}.
      */
-    deserialize?: ParamDeserializer<Unpack<T>>;
+    deserialize?: ParamDeserializer<U>;
 
     /**
      * Whether this parameter can take on multiple values at once.
@@ -46,10 +46,8 @@ export interface QueryParamOpts<T> {
      * that if the parameter is not defined on the URL, this value will be written
      * to the form control. Vice versa, if the form control takes on this value,
      * the URL parameter will be removed.
-     *
-     * NOTE: This does currently not work in combination with {@link QueryParamOpts#multi}.
      */
-    emptyOn?: Unpack<T>;
+    emptyOn?: T;
 
     /**
      * The comparator to be used with {@link QueryParamOpts#emptyOn}.
@@ -59,7 +57,7 @@ export interface QueryParamOpts<T> {
      *
      * See {@link Comparator}.
      */
-    compareWith?: Comparator<Unpack<T>>;
+    compareWith?: Comparator<T>;
 
     /**
      * Execute a side effect on other query parameters.
@@ -72,4 +70,9 @@ export interface QueryParamOpts<T> {
      *       (de-)serializers are run and no recursion is applied.
      */
     combineWith?: ParamCombinator<T>;
+}
+
+/** See {@link QueryParamOpts}. */
+export interface MultiQueryParamOpts<T> extends QueryParamOpts<T, T[]> {
+    multi: true;
 }

--- a/projects/ngqp/core/src/lib/model/query-param.spec.ts
+++ b/projects/ngqp/core/src/lib/model/query-param.spec.ts
@@ -1,14 +1,14 @@
 import { fakeAsync } from '@angular/core/testing';
-import { QueryParam } from './query-param';
+import { QueryParam, MultiQueryParam } from './query-param';
 import { QueryParamOpts } from './query-param-opts';
 import { LOOSE_IDENTITY_COMPARATOR } from '../util';
 import { DEFAULT_STRING_DESERIALIZER, DEFAULT_STRING_SERIALIZER } from '../serializers';
 import { QueryParamGroup } from './query-param-group';
 import { captureObservable, scheduler } from '../../test/util';
 
-describe(QueryParam.name, () => {
+describe('QueryParam', () => {
     describe('constructor', () => {
-        const opts: Required<QueryParamOpts<any>> = {
+        const opts: Required<QueryParamOpts<any, any>> = {
             serialize: (value: any) => '',
             deserialize: (value: string) => value,
             multi: false,
@@ -51,15 +51,6 @@ describe(QueryParam.name, () => {
                 emptyOn: 42,
                 compareWith: undefined,
             })).toThrowError('compareWith must be a function, but received undefined');
-        });
-
-        it('throws an error if emptyOn is provided together with multi', () => {
-            expect(() => new QueryParam('q', {
-                ...opts,
-                multi: true,
-                emptyOn: 42,
-                compareWith: LOOSE_IDENTITY_COMPARATOR,
-            })).toThrowError('emptyOn is only supported for single-value parameters, but q is a multi-value parameter.');
         });
 
         it('does not require combineWith', () => {

--- a/projects/ngqp/core/src/lib/query-param-builder.service.spec.ts
+++ b/projects/ngqp/core/src/lib/query-param-builder.service.spec.ts
@@ -1,6 +1,6 @@
 import { QueryParamBuilder } from './query-param-builder.service';
 import { QueryParamGroup } from './model/query-param-group';
-import { QueryParam } from './model/query-param';
+import { MultiQueryParam, QueryParam } from './model/query-param';
 
 interface Item {
     name: string;
@@ -27,7 +27,7 @@ describe(QueryParamBuilder.name, () => {
         });
 
         it('can create a multi parameter', () => {
-            const param: QueryParam<string[]> = qpb.stringParam('q', { multi: true });
+            const param: MultiQueryParam<string> = qpb.stringParam('q', { multi: true });
             expect(param).toBeTruthy();
         });
     });
@@ -39,7 +39,7 @@ describe(QueryParamBuilder.name, () => {
         });
 
         it('can create a multi parameter', () => {
-            const param: QueryParam<number[]> = qpb.numberParam('q', { multi: true });
+            const param: MultiQueryParam<number> = qpb.numberParam('q', { multi: true });
             expect(param).toBeTruthy();
         });
     });
@@ -51,7 +51,7 @@ describe(QueryParamBuilder.name, () => {
         });
 
         it('can create a multi parameter', () => {
-            const param: QueryParam<boolean[]> = qpb.booleanParam('q', { multi: true });
+            const param: MultiQueryParam<boolean> = qpb.booleanParam('q', { multi: true });
             expect(param).toBeTruthy();
         });
     });
@@ -66,7 +66,7 @@ describe(QueryParamBuilder.name, () => {
         });
 
         it('can create a multi parameter', () => {
-            const param: QueryParam<Item[]> = qpb.param<Item>('q', {
+            const param: MultiQueryParam<Item> = qpb.param<Item>('q', {
                 multi: true,
                 serialize: () => '',
                 deserialize: () => undefined,

--- a/projects/ngqp/core/src/lib/query-param-builder.service.ts
+++ b/projects/ngqp/core/src/lib/query-param-builder.service.ts
@@ -9,9 +9,13 @@ import {
 } from './serializers';
 import { LOOSE_IDENTITY_COMPARATOR } from './util';
 import { RouterOptions } from './router-adapter/router-adapter.interface';
-import { QueryParam } from './model/query-param';
+import { MultiQueryParam, QueryParam } from './model/query-param';
 import { QueryParamGroup } from './model/query-param-group';
-import { QueryParamOpts } from './model/query-param-opts';
+import { MultiQueryParamOpts, QueryParamOpts } from './model/query-param-opts';
+
+function isMultiOpts<T>(opts: QueryParamOpts<T> | MultiQueryParamOpts<T>): opts is MultiQueryParamOpts<T> {
+    return opts.multi === true;
+}
 
 /**
  * Service to create parameters and groups.
@@ -35,7 +39,7 @@ export class QueryParamBuilder {
      * @returns The new {@link QueryParamGroup}.
      */
     public group(
-        queryParams: { [ name: string ]: QueryParam<any> },
+        queryParams: { [ name: string ]: QueryParam<unknown> },
         extras: RouterOptions = {}
     ): QueryParamGroup {
         // TODO Maybe we should first validate that no two queryParams defined the same "param".
@@ -43,7 +47,7 @@ export class QueryParamBuilder {
     }
 
     /** @ignore */
-    public stringParam(urlParam: string, opts: QueryParamOpts<string[]> & { multi: true }): QueryParam<string[]>;
+    public stringParam(urlParam: string, opts: MultiQueryParamOpts<string>): MultiQueryParam<string>;
     /** @ignore */
     public stringParam(urlParam: string, opts?: QueryParamOpts<string>): QueryParam<string>;
     /**
@@ -53,18 +57,24 @@ export class QueryParamBuilder {
      */
     public stringParam(
         urlParam: string,
-        opts: QueryParamOpts<string> | QueryParamOpts<string[]> = {}
-    ): QueryParam<string> | QueryParam<string[]> {
-        return new QueryParam<any>(urlParam, {
+        opts: QueryParamOpts<string> | MultiQueryParamOpts<string> = {}
+    ): QueryParam<string> | MultiQueryParam<string> {
+        opts = {
             serialize: DEFAULT_STRING_SERIALIZER,
             deserialize: DEFAULT_STRING_DESERIALIZER,
             compareWith: LOOSE_IDENTITY_COMPARATOR,
             ...opts,
-        } as QueryParamOpts<any>);
+        };
+
+        if (isMultiOpts(opts)) {
+            return new MultiQueryParam<string>(urlParam, opts);
+        } else {
+            return new QueryParam<string>(urlParam, opts);
+        }
     }
 
     /** @ignore */
-    public numberParam(urlParam: string, opts: QueryParamOpts<number[]> & { multi: true }): QueryParam<number[]>;
+    public numberParam(urlParam: string, opts: MultiQueryParamOpts<number>): MultiQueryParam<number>;
     /** @ignore */
     public numberParam(urlParam: string, opts?: QueryParamOpts<number>): QueryParam<number>;
     /**
@@ -74,18 +84,24 @@ export class QueryParamBuilder {
      */
     public numberParam(
         urlParam: string,
-        opts: QueryParamOpts<number> | QueryParamOpts<number[]> = {}
-    ): QueryParam<number> | QueryParam<number[]> {
-        return new QueryParam<any>(urlParam, {
+        opts: QueryParamOpts<number> | MultiQueryParamOpts<number> = {}
+    ): QueryParam<number> | MultiQueryParam<number> {
+        opts = {
             serialize: DEFAULT_NUMBER_SERIALIZER,
             deserialize: DEFAULT_NUMBER_DESERIALIZER,
             compareWith: LOOSE_IDENTITY_COMPARATOR,
             ...opts,
-        } as QueryParamOpts<any>);
+        };
+
+        if (isMultiOpts(opts)) {
+            return new MultiQueryParam<number>(urlParam, opts);
+        } else {
+            return new QueryParam<number>(urlParam, opts);
+        }
     }
 
     /** @ignore */
-    public booleanParam(urlParam: string, opts: QueryParamOpts<boolean[]> & { multi: true }): QueryParam<boolean[]>;
+    public booleanParam(urlParam: string, opts: MultiQueryParamOpts<boolean>): MultiQueryParam<boolean>;
     /** @ignore */
     public booleanParam(urlParam: string, opts?: QueryParamOpts<boolean>): QueryParam<boolean>;
     /**
@@ -95,18 +111,24 @@ export class QueryParamBuilder {
      */
     public booleanParam(
         urlParam: string,
-        opts: QueryParamOpts<boolean> | QueryParamOpts<boolean[]> = {}
-    ): QueryParam<boolean> | QueryParam<boolean[]> {
-        return new QueryParam<any>(urlParam, {
+        opts: QueryParamOpts<boolean> | MultiQueryParamOpts<boolean> = {}
+    ): QueryParam<boolean> | MultiQueryParam<boolean> {
+        opts = {
             serialize: DEFAULT_BOOLEAN_SERIALIZER,
             deserialize: DEFAULT_BOOLEAN_DESERIALIZER,
             compareWith: LOOSE_IDENTITY_COMPARATOR,
             ...opts,
-        } as QueryParamOpts<any>);
+        };
+
+        if (isMultiOpts(opts)) {
+            return new MultiQueryParam<boolean>(urlParam, opts);
+        } else {
+            return new QueryParam<boolean>(urlParam, opts);
+        }
     }
 
     /** @ignore */
-    public param<T>(urlParam: string, opts: QueryParamOpts<T[]> & { multi: true }): QueryParam<T[]>;
+    public param<T>(urlParam: string, opts: MultiQueryParamOpts<T>): MultiQueryParam<T>;
     /** @ignore */
     public param<T>(urlParam: string, opts?: QueryParamOpts<T>): QueryParam<T>;
     /**
@@ -116,12 +138,18 @@ export class QueryParamBuilder {
      */
     public param<T>(
         urlParam: string,
-        opts: QueryParamOpts<T> | QueryParamOpts<T[]> = {}
-    ): QueryParam<T> | QueryParam<T[]> {
-        return new QueryParam<any>(urlParam, {
+        opts: QueryParamOpts<T> | MultiQueryParamOpts<T> = {}
+    ): QueryParam<T> | MultiQueryParam<T> {
+        opts = {
             compareWith: LOOSE_IDENTITY_COMPARATOR,
             ...opts,
-        } as QueryParamOpts<any>);
+        };
+
+        if (isMultiOpts(opts)) {
+            return new MultiQueryParam<T>(urlParam, opts);
+        } else {
+            return new QueryParam<T>(urlParam, opts);
+        }
     }
 
 }

--- a/projects/ngqp/core/src/lib/serializers.spec.ts
+++ b/projects/ngqp/core/src/lib/serializers.spec.ts
@@ -1,8 +1,6 @@
 import {
     createBooleanDeserializer,
     createBooleanSerializer,
-    createEmptyOnDeserializer,
-    createEmptyOnSerializer,
     createNumberDeserializer,
     createNumberSerializer,
     createStringDeserializer,
@@ -81,53 +79,6 @@ describe('Default (de-)serializer', () => {
             testDeserialize(deserializer, 'foo', false);
         });
     })(DEFAULT_BOOLEAN_DESERIALIZER);
-});
-
-describe('emptyOn (de-)serializer', () => {
-    (serializer => {
-        describe('for strings', () => {
-            testSerialize(serializer, '', '');
-            testSerialize(serializer, 'Test', null);
-        });
-    })(createEmptyOnSerializer(createStringSerializer(), 'Test', LOOSE_IDENTITY_COMPARATOR));
-
-    (deserializer => {
-        describe('for strings', () => {
-            testDeserialize(deserializer, '', '');
-            testDeserialize(deserializer, 'Test', 'Test');
-            testDeserialize(deserializer, null, 'Test');
-        });
-    })(createEmptyOnDeserializer(createStringDeserializer(), 'Test'));
-
-    (serializer => {
-        describe('for numbers', () => {
-            testSerialize(serializer, 42, null);
-            testSerialize(serializer, 13.37, '13.37');
-        });
-    })(createEmptyOnSerializer(createNumberSerializer(), 42, LOOSE_IDENTITY_COMPARATOR));
-
-    (deserializer => {
-    describe('for numbers', () => {
-        testDeserialize(deserializer, null, 42);
-        testDeserialize(deserializer, '42', 42);
-        testDeserialize(deserializer, '13.37', 13.37);
-    });
-    })(createEmptyOnDeserializer(createNumberDeserializer(), 42));
-
-    (serializer => {
-        describe('for booleans', () => {
-            testSerialize(serializer, true, null);
-            testSerialize(serializer, false, 'false');
-        });
-    })(createEmptyOnSerializer(createBooleanSerializer(), true, LOOSE_IDENTITY_COMPARATOR));
-
-    (deserializer => {
-        describe('for booleans', () => {
-            testDeserialize(deserializer, 'true', true);
-            testDeserialize(deserializer, null, true);
-            testDeserialize(deserializer, 'false', false);
-        });
-    })(createEmptyOnDeserializer(createBooleanDeserializer(), true));
 });
 
 describe(LOOSE_IDENTITY_COMPARATOR.name, () => {

--- a/projects/ngqp/core/src/lib/serializers.ts
+++ b/projects/ngqp/core/src/lib/serializers.ts
@@ -2,35 +2,6 @@ import { areEqualUsing, isMissing } from './util';
 import { Comparator, ParamDeserializer, ParamSerializer } from './types';
 
 /**
- * Wraps a serializer which defaults to the given value.
- *
- * This function returns a new serializer which mirrors the given serializer,
- * except that if the given default value equals the value to be serialized
- * (using the provided comparator), `null` is returned instead.
- *
- * @param serializer The serializer to wrap and mirror.
- * @param emptyOn The default value for which the serialization should return `null`.
- * @param compareWith The comparator function to compare two values.
- */
-export function createEmptyOnSerializer<T>(serializer: ParamSerializer<T>, emptyOn: T, compareWith: Comparator<T>): ParamSerializer<T> {
-    return model => areEqualUsing(model, emptyOn, compareWith) ? null : serializer(model);
-}
-
-/**
- * Wraps a deserializer which defaults to the given value.
- *
- * This function returns a new deserializer which mirrors the given deserializer,
- * except that on a `null` value to deserialize, the given default value is
- * returned instead.
- *
- * @param deserializer The deserializer to wrap and mirror.
- * @param emptyOn The default value to return if the value to deserialize is `null`.
- */
-export function createEmptyOnDeserializer<T>(deserializer: ParamDeserializer<T>, emptyOn: T): ParamDeserializer<T> {
-    return value => value === null ? emptyOn : deserializer(value);
-}
-
-/**
  * Creates a serializer for parameters of type `string`.
  *
  * @param defaultValue Optional default value to return if the value to serialize is `undefined` or `null`.

--- a/projects/ngqp/core/src/lib/types.ts
+++ b/projects/ngqp/core/src/lib/types.ts
@@ -33,11 +33,3 @@ export type OnChangeFunction<T> = (value: T | null) => void;
  * @returns `true` or `0` if and only if `a` and `b` should be considered equal.
  */
 export type Comparator<T> = (a: T | undefined | null, b: T | undefined | null) => boolean | number;
-
-/**
- * Unpacks an array type.
- *
- * If the given type is an array, this returns the element type,
- * otherwise it returns the provided type unchanged.
- */
-export type Unpack<T> = T extends (infer U)[] ? U : T;


### PR DESCRIPTION
This change improves the type safety by not misinterpreting an
array-valued parameter as a multi: true parameter. We also introduce a new
MultiQueryParam type as a shortcut.

As a side effect, we move the evaluation of (de-)serializing entirely to
the service and can thus now support emptyOn for multi: true parameters.

fixes #92
fixes #27

Signed-off-by: Ingo Bürk <ingo.buerk@tngtech.com>

I have verified that…
- [x] the commits in this pull request follow the [conventionalcommits](https://www.conventionalcommits.org) pattern
- [x] tests have been updated or added
- [x] documentation has been updated to reflect the changes made
