### PR TITLE
#120: Call setParent(null) when removing a param from a group

### DIFF
--- a/projects/ngqp/core/src/lib/model/query-param-group.spec.ts
+++ b/projects/ngqp/core/src/lib/model/query-param-group.spec.ts
@@ -230,6 +230,7 @@ describe(QueryParamGroup.name, () => {
         it('can remove an existing parameter from a group', () => {
             group.remove('q');
             expect(group.get('q')).toBeNull();
+            expect((stringParam as any).parent).toBe(null);
         });
 
         it('throws if the parameter does not exist', () => {

--- a/projects/ngqp/core/src/lib/model/query-param-group.spec.ts
+++ b/projects/ngqp/core/src/lib/model/query-param-group.spec.ts
@@ -207,17 +207,19 @@ describe(QueryParamGroup.name, () => {
 
     describe('add', () => {
         let group: QueryParamGroup;
-        beforeEach(() => group = new QueryParamGroup({ q: stringParam }));
+        beforeEach(() => group = new QueryParamGroup({}));
 
         it('can add a new parameter to a group', () => {
             group.add('test', stringParam);
             expect(group.get('test')).toBe(stringParam);
-            expect(group.value).toEqual({ q: null, test: null });
+            expect(group.value).toEqual({ test: null });
+            expect((stringParam as any).parent).not.toBe(null);
         });
 
         it('throws if the name is already taken', () => {
-            expect(() => group.add('q', stringParam))
-                .toThrowError('A parameter with name q already exists.');
+            group.add('test', stringParam);
+            expect(() => group.add('test', stringParam))
+                .toThrowError('A parameter with name test already exists.');
         });
     });
 

--- a/projects/ngqp/core/src/lib/model/query-param-group.ts
+++ b/projects/ngqp/core/src/lib/model/query-param-group.ts
@@ -95,6 +95,7 @@ export class QueryParamGroup {
         }
 
         this.queryParams[ queryParamName ] = queryParam;
+        queryParam._setParent(this);
         this._queryParamAdded$.next(queryParamName);
     }
 

--- a/projects/ngqp/core/src/lib/model/query-param-group.ts
+++ b/projects/ngqp/core/src/lib/model/query-param-group.ts
@@ -115,6 +115,7 @@ export class QueryParamGroup {
         }
 
         delete this.queryParams[ queryParamName ];
+        queryParam._setParent(null);
         queryParam._clearChangeFunctions();
     }
 

--- a/projects/ngqp/core/src/lib/model/query-param.ts
+++ b/projects/ngqp/core/src/lib/model/query-param.ts
@@ -9,7 +9,7 @@ abstract class AbstractQueryParamBase<T> {
 
     public abstract value: T;
 
-    protected parent: QueryParamGroup;
+    protected parent: QueryParamGroup | null = null;
     protected _valueChanges = new Subject<T>();
     protected changeFunctions: OnChangeFunction<T>[] = [];
 
@@ -35,7 +35,7 @@ abstract class AbstractQueryParamBase<T> {
     }): void;
 
     public _setParent(parent: QueryParamGroup): void {
-        if (this.parent) {
+        if (this.parent && parent) {
             throw new Error(`Parameter already belongs to a QueryParamGroup.`);
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to @ngqp! Please read the following and make sure your PR is following this template.
-->

<!-- Provide a list of issue numbers relating to this PR -->
This pull request relates to or closes the following issues:

I have verified that…
- [ ] the commits in this pull request follow the [conventionalcommits](https://www.conventionalcommits.org) pattern
- [ ] tests have been updated or added
- [ ] documentation has been updated to reflect the changes made
