### PR TITLE
fix(core): allow QueryParamGroup#setValue to be called with null

### DIFF
--- a/projects/ngqp/core/src/lib/model/query-param-group.spec.ts
+++ b/projects/ngqp/core/src/lib/model/query-param-group.spec.ts
@@ -127,6 +127,12 @@ describe(QueryParamGroup.name, () => {
             expect(stringParam.value).toBeNull();
         });
 
+        it('allows null as the value', () => {
+            stringParam.value = 'Test';
+            group.setValue(null);
+            expect(stringParam.value).toBeNull();
+        });
+
         it('ignores non-existing parameters', () => {
             expect(() => group.setValue({ foo: 42 })).not.toThrow();
         });

--- a/projects/ngqp/core/src/lib/model/query-param-group.ts
+++ b/projects/ngqp/core/src/lib/model/query-param-group.ts
@@ -170,12 +170,12 @@ export class QueryParamGroup {
      * @param value See {@link QueryParamGroup#valueChanges} for a description of the format.
      * @param opts Additional options
      */
-    public setValue(value: Record<string, any>, opts: {
+    public setValue(value: Record<string, any> | null, opts: {
         emitEvent?: boolean,
         emitModelToViewChange?: boolean,
     } = {}): void {
         Object.keys(this.queryParams).forEach(queryParamName => {
-            this.queryParams[ queryParamName ].setValue(undefinedToNull(value[ queryParamName ]), {
+            this.queryParams[ queryParamName ].setValue(undefinedToNull(value?.[ queryParamName ]), {
                 emitEvent: opts.emitEvent,
                 onlySelf: true,
                 emitModelToViewChange: false,


### PR DESCRIPTION
relates #172

Signed-off-by: Ingo Bürk <ingo.buerk@tngtech.com>

<!--
Thank you for contributing to @ngqp! Please read the following and make sure your PR is following this template.
-->

<!-- Provide a list of issue numbers relating to this PR -->
This pull request relates to or closes the following issues:

I have verified that…
- [x] the commits in this pull request follow the [conventionalcommits](https://www.conventionalcommits.org) pattern
- [x] tests have been updated or added
- [x] documentation has been updated to reflect the changes made
