### PR TITLE
feat(core): added clearOnDestroy

### DIFF
--- a/projects/ngqp-demo/src/app/docs-items/configuration/query-param-group/query-param-group-configuration-docs.component.html
+++ b/projects/ngqp-demo/src/app/docs-items/configuration/query-param-group/query-param-group-configuration-docs.component.html
@@ -30,4 +30,14 @@
         Defines whether a possibly set fragment in the URL should be preserved.
     </p>
     <demo-snippet type="typescript" [code]="preserveFragmentConfigSnippet"></demo-snippet>
+
+    <docs-fragment fragment="clearOnDestroy">
+        <h3>clearOnDestroy</h3>
+    </docs-fragment>
+    <p>
+        Remove query parameters from URL when the <span apiDocsLink>QueryParamGroup</span> goes out of scope.
+        This can be useful if you want to temporarily synchronize query parameters in a modal, but remove them
+        when the modal is closed.
+    </p>
+    <demo-snippet type="typescript" [code]="clearOnDestroyConfigSnippet"></demo-snippet>
 </docs-item>

--- a/projects/ngqp-demo/src/app/docs-items/configuration/query-param-group/query-param-group-configuration-docs.component.ts
+++ b/projects/ngqp-demo/src/app/docs-items/configuration/query-param-group/query-param-group-configuration-docs.component.ts
@@ -12,5 +12,6 @@ export class QueryParamGroupConfigurationDocsComponent {
 
     public readonly configSnippet = require('!raw-loader!./snippets/qpg-config.example.ts').default;
     public readonly preserveFragmentConfigSnippet = require('!raw-loader!./snippets/qpg-config-preserveFragment.example.ts').default;
+    public readonly clearOnDestroyConfigSnippet = require('!raw-loader!./snippets/qpg-config-clearOnDestroy.example.ts').default;
 
 }

--- a/projects/ngqp-demo/src/app/docs-items/configuration/query-param-group/snippets/qpg-config-clearOnDestroy.example.ts
+++ b/projects/ngqp-demo/src/app/docs-items/configuration/query-param-group/snippets/qpg-config-clearOnDestroy.example.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { QueryParamBuilder, QueryParamGroup } from '@ngqp/core';
+
+@Component({
+    selector: 'app-example',
+})
+export class ExampleComponent {
+
+    public paramGroup: QueryParamGroup;
+
+    constructor(private qpb: QueryParamBuilder) {
+        this.paramGroup = qpb.group({
+            // …
+        }, {
+            clearOnDestroy: true,
+        });
+    }
+
+}

--- a/projects/ngqp/core/src/lib/directives/query-param-group.service.ts
+++ b/projects/ngqp/core/src/lib/directives/query-param-group.service.ts
@@ -75,10 +75,20 @@ export class QueryParamGroupService implements OnDestroy {
 
         this.synchronizeRouter$.complete();
 
-        if (this.queryParamGroup) {
-            this.queryParamGroup._clearChangeFunctions();
+        this.queryParamGroup?._clearChangeFunctions();
+        if (this.queryParamGroup?.options?.clearOnDestroy) {
+            const nullParams = Object.values(this.queryParamGroup.queryParams)
+                .map(queryParam => this.wrapIntoPartition(queryParam))
+                .map(partitionedQueryParam => partitionedQueryParam.queryParams.map(queryParam => queryParam.urlParam))
+                .reduce((a, b) => [...a, ...b], [])
+                .map(urlParam => ({[urlParam]: null}))
+                .reduce((a, b) => ({...a, ...b}), {});
+            this.routerAdapter.navigate(nullParams, {
+                replaceUrl: true,
+            }).then();
         }
     }
+
 
     /**
      * Uses the given {@link QueryParamGroup} for synchronization.

--- a/projects/ngqp/core/src/lib/model/query-param-group.ts
+++ b/projects/ngqp/core/src/lib/model/query-param-group.ts
@@ -3,6 +3,7 @@ import { isMissing, undefinedToNull } from '../util';
 import { OnChangeFunction } from '../types';
 import { MultiQueryParam, QueryParam, PartitionedQueryParam } from './query-param';
 import { RouterOptions } from '../router-adapter/router-adapter.interface';
+import {QueryParamGroupOpts} from './query-param-opts';
 
 /**
  * Groups multiple {@link QueryParam} instances to a single unit.
@@ -39,14 +40,18 @@ export class QueryParamGroup {
     /** @internal */
     public readonly routerOptions: RouterOptions;
 
+    /** @internal */
+    public readonly options: QueryParamGroupOpts;
+
     private changeFunctions: OnChangeFunction<Record<string, any>>[] = [];
 
     constructor(
         queryParams: { [ queryParamName: string ]: QueryParam<unknown> | MultiQueryParam<unknown> | PartitionedQueryParam<unknown> },
-        extras: RouterOptions = {}
+        extras: RouterOptions & QueryParamGroupOpts = {}
     ) {
         this.queryParams = queryParams;
         this.routerOptions = extras;
+        this.options = extras;
 
         Object.values(this.queryParams).forEach(queryParam => queryParam._setParent(this));
     }

--- a/projects/ngqp/core/src/lib/model/query-param-opts.ts
+++ b/projects/ngqp/core/src/lib/model/query-param-opts.ts
@@ -1,6 +1,17 @@
 import { Comparator, Reducer, Partitioner, ParamCombinator, ParamDeserializer, ParamSerializer } from '../types';
 
 /**
+ * Configuration options for a {@link QueryParamGroup}.
+ */
+export interface QueryParamGroupOpts {
+    /**
+     * If set to {@code true} the query parameters will be removed from the URL when the directive
+     * binding it goes out of scope (i.e., is destroyed).
+     */
+    clearOnDestroy?: boolean;
+}
+
+/**
  * List of options which can be passed to {@link QueryParam}.
  */
 export interface QueryParamOptsBase<U, T> {

--- a/projects/ngqp/core/src/lib/query-param-builder.service.ts
+++ b/projects/ngqp/core/src/lib/query-param-builder.service.ts
@@ -11,7 +11,12 @@ import { LOOSE_IDENTITY_COMPARATOR } from './util';
 import { RouterOptions } from './router-adapter/router-adapter.interface';
 import { MultiQueryParam, QueryParam, PartitionedQueryParam } from './model/query-param';
 import { QueryParamGroup } from './model/query-param-group';
-import { MultiQueryParamOpts, PartitionedQueryParamOpts, QueryParamOpts } from './model/query-param-opts';
+import {
+    MultiQueryParamOpts,
+    PartitionedQueryParamOpts,
+    QueryParamGroupOpts,
+    QueryParamOpts
+} from './model/query-param-opts';
 
 function isMultiOpts<T>(opts: QueryParamOpts<T> | MultiQueryParamOpts<T>): opts is MultiQueryParamOpts<T> {
     return opts.multi === true;
@@ -40,7 +45,7 @@ export class QueryParamBuilder {
      */
     public group(
         queryParams: { [ name: string ]: QueryParam<any> | MultiQueryParam<any> | PartitionedQueryParam<any> },
-        extras: RouterOptions = {}
+        extras: RouterOptions & QueryParamGroupOpts = {}
     ): QueryParamGroup {
         // TODO Maybe we should first validate that no two queryParams defined the same "param".
         return new QueryParamGroup(queryParams, extras);

--- a/projects/ngqp/core/src/test/clear-on-destroy.spec.ts
+++ b/projects/ngqp/core/src/test/clear-on-destroy.spec.ts
@@ -1,0 +1,91 @@
+import {Component, Input} from '@angular/core';
+import { Router } from '@angular/router';
+import { waitForAsync, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { QueryParamBuilder, QueryParamGroup, QueryParamModule } from '../public_api';
+import { setupNavigationWarnStub } from './util';
+
+@Component({
+    template: `<child *ngIf="shown" [paramGroup]="paramGroup"></child>`,
+})
+class TestComponent {
+    public shown = true;
+    public paramGroup: QueryParamGroup;
+
+    constructor(private qpb: QueryParamBuilder) {
+        this.paramGroup = qpb.group({
+            stringParam: qpb.stringParam('p1'),
+            partitionedParam: qpb.partition([
+                qpb.stringParam('p2a'),
+                qpb.stringParam('p2b'),
+            ], {
+                partition: (v: string): [string, string] => [v[0], v[1]],
+                reduce: ([v1, v2]) => v1 + v2,
+            }),
+        }, {
+            clearOnDestroy: true,
+        });
+    }
+}
+
+@Component({
+    selector: 'child',
+    template: `<div [queryParamGroup]="paramGroup"></div>`,
+})
+class ChildComponent {
+    @Input()
+    public paramGroup: QueryParamGroup;
+}
+
+describe('ngqp', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let component: TestComponent;
+    let router: Router;
+
+    beforeEach(() => setupNavigationWarnStub());
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                RouterTestingModule.withRoutes([]),
+                QueryParamModule,
+            ],
+            declarations: [
+                TestComponent,
+                ChildComponent,
+            ],
+        });
+
+        router = TestBed.inject(Router);
+        TestBed.compileComponents();
+        router.initialNavigation();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('clears managed query parameters if clearOnDestroy is set', fakeAsync(() => {
+        // Make sure non-managed parameters are not cleared
+        router.navigate([], {
+            queryParams: {
+                q: 'Test'
+            },
+        });
+        tick();
+
+        component.paramGroup.setValue({
+            stringParam: 'S',
+            partitionedParam: ['A', 'B'],
+        });
+        tick();
+        expect(router.url).toBe('/?q=Test&p1=S&p2a=A&p2b=B');
+
+        component.shown = false;
+        fixture.detectChanges();
+        tick();
+        expect(router.url).toBe('/?q=Test');
+    }));
+});


### PR DESCRIPTION
When set, the query params managed by the QueryParamGroup are cleared from
the URL when the directive binding this group goes out of scope.

fixes #172

Signed-off-by: Ingo Bürk <ingo.buerk@tngtech.com>

<!--
Thank you for contributing to @ngqp! Please read the following and make sure your PR is following this template.
-->

<!-- Provide a list of issue numbers relating to this PR -->
This pull request relates to or closes the following issues:

I have verified that…
- [x] the commits in this pull request follow the [conventionalcommits](https://www.conventionalcommits.org) pattern
- [x] tests have been updated or added
- [x] documentation has been updated to reflect the changes made
