### PR TITLE
chore: support ivy based partial compilation for @ngqp/core

### DIFF
--- a/projects/ngqp/core/tsconfig.lib.prod.json
+++ b/projects/ngqp/core/tsconfig.lib.prod.json
@@ -4,6 +4,6 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "enableIvy": false
+    "enableIvy": true
   }
 }


### PR DESCRIPTION
Library should be compiled using "compilationMode": "partial" for not using ngcc
Also default target for 14 angular is es2020
Update browserlist to actual due to bugs with old data
Change legacy "fullTemplateTypeCheck" to actual "strictTemplates"

BREAKING CHANGE: due to partial ivy compilation it's not supported by angular before 11.1 so bump version to 15

closes #224

<!--
Thank you for contributing to @ngqp! Please read the following and make sure your PR is following this template.
-->

<!-- Provide a list of issue numbers relating to this PR -->
This pull request relates to or closes the following issues:

I have verified that…
- [x] the commits in this pull request follow the [conventionalcommits](https://www.conventionalcommits.org) pattern
- [ ] tests have been updated or added
- [ ] documentation has been updated to reflect the changes made
